### PR TITLE
bug fix: only choose closest shortcut in same year

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quarterpastmarch"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Mike Moran <mike@houseofmoran.com>"]
 edition = "2018"
 
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 askama = "0.9"
+itertools = "0.8"

--- a/public/2020-12-16/index.html
+++ b/public/2020-12-16/index.html
@@ -22,9 +22,9 @@
               2020-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-17/index.html
+++ b/public/2020-12-17/index.html
@@ -22,9 +22,9 @@
               2020-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-18/index.html
+++ b/public/2020-12-18/index.html
@@ -22,9 +22,9 @@
               2020-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-19/index.html
+++ b/public/2020-12-19/index.html
@@ -22,9 +22,9 @@
               2020-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-20/index.html
+++ b/public/2020-12-20/index.html
@@ -22,9 +22,9 @@
               2020-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-21/index.html
+++ b/public/2020-12-21/index.html
@@ -22,9 +22,9 @@
               2020-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-22/index.html
+++ b/public/2020-12-22/index.html
@@ -22,9 +22,9 @@
               2020-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-23/index.html
+++ b/public/2020-12-23/index.html
@@ -22,9 +22,9 @@
               2020-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-24/index.html
+++ b/public/2020-12-24/index.html
@@ -22,9 +22,9 @@
               2020-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-25/index.html
+++ b/public/2020-12-25/index.html
@@ -22,9 +22,9 @@
               2020-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-26/index.html
+++ b/public/2020-12-26/index.html
@@ -22,9 +22,9 @@
               2020-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-27/index.html
+++ b/public/2020-12-27/index.html
@@ -22,9 +22,9 @@
               2020-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-28/index.html
+++ b/public/2020-12-28/index.html
@@ -22,9 +22,9 @@
               2020-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-29/index.html
+++ b/public/2020-12-29/index.html
@@ -22,9 +22,9 @@
               2020-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-30/index.html
+++ b/public/2020-12-30/index.html
@@ -22,9 +22,9 @@
               2020-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2020-12-31/index.html
+++ b/public/2020-12-31/index.html
@@ -22,9 +22,9 @@
               2020-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-16/index.html
+++ b/public/2021-12-16/index.html
@@ -22,9 +22,9 @@
               2021-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-17/index.html
+++ b/public/2021-12-17/index.html
@@ -22,9 +22,9 @@
               2021-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-18/index.html
+++ b/public/2021-12-18/index.html
@@ -22,9 +22,9 @@
               2021-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-19/index.html
+++ b/public/2021-12-19/index.html
@@ -22,9 +22,9 @@
               2021-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-20/index.html
+++ b/public/2021-12-20/index.html
@@ -22,9 +22,9 @@
               2021-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-21/index.html
+++ b/public/2021-12-21/index.html
@@ -22,9 +22,9 @@
               2021-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-22/index.html
+++ b/public/2021-12-22/index.html
@@ -22,9 +22,9 @@
               2021-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-23/index.html
+++ b/public/2021-12-23/index.html
@@ -22,9 +22,9 @@
               2021-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-24/index.html
+++ b/public/2021-12-24/index.html
@@ -22,9 +22,9 @@
               2021-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-25/index.html
+++ b/public/2021-12-25/index.html
@@ -22,9 +22,9 @@
               2021-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-26/index.html
+++ b/public/2021-12-26/index.html
@@ -22,9 +22,9 @@
               2021-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-27/index.html
+++ b/public/2021-12-27/index.html
@@ -22,9 +22,9 @@
               2021-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-28/index.html
+++ b/public/2021-12-28/index.html
@@ -22,9 +22,9 @@
               2021-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-29/index.html
+++ b/public/2021-12-29/index.html
@@ -22,9 +22,9 @@
               2021-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-30/index.html
+++ b/public/2021-12-30/index.html
@@ -22,9 +22,9 @@
               2021-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2021-12-31/index.html
+++ b/public/2021-12-31/index.html
@@ -22,9 +22,9 @@
               2021-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-16/index.html
+++ b/public/2022-12-16/index.html
@@ -22,9 +22,9 @@
               2022-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-17/index.html
+++ b/public/2022-12-17/index.html
@@ -22,9 +22,9 @@
               2022-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-18/index.html
+++ b/public/2022-12-18/index.html
@@ -22,9 +22,9 @@
               2022-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-19/index.html
+++ b/public/2022-12-19/index.html
@@ -22,9 +22,9 @@
               2022-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-20/index.html
+++ b/public/2022-12-20/index.html
@@ -22,9 +22,9 @@
               2022-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-21/index.html
+++ b/public/2022-12-21/index.html
@@ -22,9 +22,9 @@
               2022-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-22/index.html
+++ b/public/2022-12-22/index.html
@@ -22,9 +22,9 @@
               2022-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-23/index.html
+++ b/public/2022-12-23/index.html
@@ -22,9 +22,9 @@
               2022-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-24/index.html
+++ b/public/2022-12-24/index.html
@@ -22,9 +22,9 @@
               2022-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-25/index.html
+++ b/public/2022-12-25/index.html
@@ -22,9 +22,9 @@
               2022-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-26/index.html
+++ b/public/2022-12-26/index.html
@@ -22,9 +22,9 @@
               2022-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-27/index.html
+++ b/public/2022-12-27/index.html
@@ -22,9 +22,9 @@
               2022-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-28/index.html
+++ b/public/2022-12-28/index.html
@@ -22,9 +22,9 @@
               2022-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-29/index.html
+++ b/public/2022-12-29/index.html
@@ -22,9 +22,9 @@
               2022-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-30/index.html
+++ b/public/2022-12-30/index.html
@@ -22,9 +22,9 @@
               2022-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2022-12-31/index.html
+++ b/public/2022-12-31/index.html
@@ -22,9 +22,9 @@
               2022-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-16/index.html
+++ b/public/2023-12-16/index.html
@@ -22,9 +22,9 @@
               2023-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-17/index.html
+++ b/public/2023-12-17/index.html
@@ -22,9 +22,9 @@
               2023-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-18/index.html
+++ b/public/2023-12-18/index.html
@@ -22,9 +22,9 @@
               2023-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-19/index.html
+++ b/public/2023-12-19/index.html
@@ -22,9 +22,9 @@
               2023-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-20/index.html
+++ b/public/2023-12-20/index.html
@@ -22,9 +22,9 @@
               2023-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-21/index.html
+++ b/public/2023-12-21/index.html
@@ -22,9 +22,9 @@
               2023-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-22/index.html
+++ b/public/2023-12-22/index.html
@@ -22,9 +22,9 @@
               2023-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-23/index.html
+++ b/public/2023-12-23/index.html
@@ -22,9 +22,9 @@
               2023-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-24/index.html
+++ b/public/2023-12-24/index.html
@@ -22,9 +22,9 @@
               2023-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-25/index.html
+++ b/public/2023-12-25/index.html
@@ -22,9 +22,9 @@
               2023-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-26/index.html
+++ b/public/2023-12-26/index.html
@@ -22,9 +22,9 @@
               2023-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-27/index.html
+++ b/public/2023-12-27/index.html
@@ -22,9 +22,9 @@
               2023-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-28/index.html
+++ b/public/2023-12-28/index.html
@@ -22,9 +22,9 @@
               2023-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-29/index.html
+++ b/public/2023-12-29/index.html
@@ -22,9 +22,9 @@
               2023-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-30/index.html
+++ b/public/2023-12-30/index.html
@@ -22,9 +22,9 @@
               2023-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2023-12-31/index.html
+++ b/public/2023-12-31/index.html
@@ -22,9 +22,9 @@
               2023-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-16/index.html
+++ b/public/2024-12-16/index.html
@@ -22,9 +22,9 @@
               2024-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-17/index.html
+++ b/public/2024-12-17/index.html
@@ -22,9 +22,9 @@
               2024-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-18/index.html
+++ b/public/2024-12-18/index.html
@@ -22,9 +22,9 @@
               2024-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-19/index.html
+++ b/public/2024-12-19/index.html
@@ -22,9 +22,9 @@
               2024-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-20/index.html
+++ b/public/2024-12-20/index.html
@@ -22,9 +22,9 @@
               2024-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-21/index.html
+++ b/public/2024-12-21/index.html
@@ -22,9 +22,9 @@
               2024-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-22/index.html
+++ b/public/2024-12-22/index.html
@@ -22,9 +22,9 @@
               2024-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-23/index.html
+++ b/public/2024-12-23/index.html
@@ -22,9 +22,9 @@
               2024-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-24/index.html
+++ b/public/2024-12-24/index.html
@@ -22,9 +22,9 @@
               2024-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-25/index.html
+++ b/public/2024-12-25/index.html
@@ -22,9 +22,9 @@
               2024-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-26/index.html
+++ b/public/2024-12-26/index.html
@@ -22,9 +22,9 @@
               2024-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-27/index.html
+++ b/public/2024-12-27/index.html
@@ -22,9 +22,9 @@
               2024-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-28/index.html
+++ b/public/2024-12-28/index.html
@@ -22,9 +22,9 @@
               2024-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-29/index.html
+++ b/public/2024-12-29/index.html
@@ -22,9 +22,9 @@
               2024-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-30/index.html
+++ b/public/2024-12-30/index.html
@@ -22,9 +22,9 @@
               2024-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2024-12-31/index.html
+++ b/public/2024-12-31/index.html
@@ -22,9 +22,9 @@
               2024-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-16/index.html
+++ b/public/2025-12-16/index.html
@@ -22,9 +22,9 @@
               2025-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-17/index.html
+++ b/public/2025-12-17/index.html
@@ -22,9 +22,9 @@
               2025-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-18/index.html
+++ b/public/2025-12-18/index.html
@@ -22,9 +22,9 @@
               2025-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-19/index.html
+++ b/public/2025-12-19/index.html
@@ -22,9 +22,9 @@
               2025-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-20/index.html
+++ b/public/2025-12-20/index.html
@@ -22,9 +22,9 @@
               2025-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-21/index.html
+++ b/public/2025-12-21/index.html
@@ -22,9 +22,9 @@
               2025-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-22/index.html
+++ b/public/2025-12-22/index.html
@@ -22,9 +22,9 @@
               2025-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-23/index.html
+++ b/public/2025-12-23/index.html
@@ -22,9 +22,9 @@
               2025-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-24/index.html
+++ b/public/2025-12-24/index.html
@@ -22,9 +22,9 @@
               2025-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-25/index.html
+++ b/public/2025-12-25/index.html
@@ -22,9 +22,9 @@
               2025-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-26/index.html
+++ b/public/2025-12-26/index.html
@@ -22,9 +22,9 @@
               2025-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-27/index.html
+++ b/public/2025-12-27/index.html
@@ -22,9 +22,9 @@
               2025-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-28/index.html
+++ b/public/2025-12-28/index.html
@@ -22,9 +22,9 @@
               2025-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-29/index.html
+++ b/public/2025-12-29/index.html
@@ -22,9 +22,9 @@
               2025-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-30/index.html
+++ b/public/2025-12-30/index.html
@@ -22,9 +22,9 @@
               2025-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2025-12-31/index.html
+++ b/public/2025-12-31/index.html
@@ -22,9 +22,9 @@
               2025-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-16/index.html
+++ b/public/2026-12-16/index.html
@@ -22,9 +22,9 @@
               2026-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-17/index.html
+++ b/public/2026-12-17/index.html
@@ -22,9 +22,9 @@
               2026-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-18/index.html
+++ b/public/2026-12-18/index.html
@@ -22,9 +22,9 @@
               2026-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-19/index.html
+++ b/public/2026-12-19/index.html
@@ -22,9 +22,9 @@
               2026-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-20/index.html
+++ b/public/2026-12-20/index.html
@@ -22,9 +22,9 @@
               2026-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-21/index.html
+++ b/public/2026-12-21/index.html
@@ -22,9 +22,9 @@
               2026-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-22/index.html
+++ b/public/2026-12-22/index.html
@@ -22,9 +22,9 @@
               2026-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-23/index.html
+++ b/public/2026-12-23/index.html
@@ -22,9 +22,9 @@
               2026-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-24/index.html
+++ b/public/2026-12-24/index.html
@@ -22,9 +22,9 @@
               2026-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-25/index.html
+++ b/public/2026-12-25/index.html
@@ -22,9 +22,9 @@
               2026-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-26/index.html
+++ b/public/2026-12-26/index.html
@@ -22,9 +22,9 @@
               2026-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-27/index.html
+++ b/public/2026-12-27/index.html
@@ -22,9 +22,9 @@
               2026-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-28/index.html
+++ b/public/2026-12-28/index.html
@@ -22,9 +22,9 @@
               2026-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-29/index.html
+++ b/public/2026-12-29/index.html
@@ -22,9 +22,9 @@
               2026-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-30/index.html
+++ b/public/2026-12-30/index.html
@@ -22,9 +22,9 @@
               2026-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2026-12-31/index.html
+++ b/public/2026-12-31/index.html
@@ -22,9 +22,9 @@
               2026-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-16/index.html
+++ b/public/2027-12-16/index.html
@@ -22,9 +22,9 @@
               2027-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-17/index.html
+++ b/public/2027-12-17/index.html
@@ -22,9 +22,9 @@
               2027-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-18/index.html
+++ b/public/2027-12-18/index.html
@@ -22,9 +22,9 @@
               2027-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-19/index.html
+++ b/public/2027-12-19/index.html
@@ -22,9 +22,9 @@
               2027-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-20/index.html
+++ b/public/2027-12-20/index.html
@@ -22,9 +22,9 @@
               2027-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-21/index.html
+++ b/public/2027-12-21/index.html
@@ -22,9 +22,9 @@
               2027-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-22/index.html
+++ b/public/2027-12-22/index.html
@@ -22,9 +22,9 @@
               2027-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-23/index.html
+++ b/public/2027-12-23/index.html
@@ -22,9 +22,9 @@
               2027-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-24/index.html
+++ b/public/2027-12-24/index.html
@@ -22,9 +22,9 @@
               2027-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-25/index.html
+++ b/public/2027-12-25/index.html
@@ -22,9 +22,9 @@
               2027-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-26/index.html
+++ b/public/2027-12-26/index.html
@@ -22,9 +22,9 @@
               2027-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-27/index.html
+++ b/public/2027-12-27/index.html
@@ -22,9 +22,9 @@
               2027-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-28/index.html
+++ b/public/2027-12-28/index.html
@@ -22,9 +22,9 @@
               2027-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-29/index.html
+++ b/public/2027-12-29/index.html
@@ -22,9 +22,9 @@
               2027-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-30/index.html
+++ b/public/2027-12-30/index.html
@@ -22,9 +22,9 @@
               2027-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2027-12-31/index.html
+++ b/public/2027-12-31/index.html
@@ -22,9 +22,9 @@
               2027-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-16/index.html
+++ b/public/2028-12-16/index.html
@@ -22,9 +22,9 @@
               2028-12-16
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-17/index.html
+++ b/public/2028-12-17/index.html
@@ -22,9 +22,9 @@
               2028-12-17
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-18/index.html
+++ b/public/2028-12-18/index.html
@@ -22,9 +22,9 @@
               2028-12-18
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-19/index.html
+++ b/public/2028-12-19/index.html
@@ -22,9 +22,9 @@
               2028-12-19
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-20/index.html
+++ b/public/2028-12-20/index.html
@@ -22,9 +22,9 @@
               2028-12-20
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-21/index.html
+++ b/public/2028-12-21/index.html
@@ -22,9 +22,9 @@
               2028-12-21
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-22/index.html
+++ b/public/2028-12-22/index.html
@@ -22,9 +22,9 @@
               2028-12-22
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-23/index.html
+++ b/public/2028-12-23/index.html
@@ -22,9 +22,9 @@
               2028-12-23
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-24/index.html
+++ b/public/2028-12-24/index.html
@@ -22,9 +22,9 @@
               2028-12-24
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-25/index.html
+++ b/public/2028-12-25/index.html
@@ -22,9 +22,9 @@
               2028-12-25
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-26/index.html
+++ b/public/2028-12-26/index.html
@@ -22,9 +22,9 @@
               2028-12-26
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-27/index.html
+++ b/public/2028-12-27/index.html
@@ -22,9 +22,9 @@
               2028-12-27
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-28/index.html
+++ b/public/2028-12-28/index.html
@@ -22,9 +22,9 @@
               2028-12-28
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-29/index.html
+++ b/public/2028-12-29/index.html
@@ -22,9 +22,9 @@
               2028-12-29
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-30/index.html
+++ b/public/2028-12-30/index.html
@@ -22,9 +22,9 @@
               2028-12-30
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>

--- a/public/2028-12-31/index.html
+++ b/public/2028-12-31/index.html
@@ -22,9 +22,9 @@
               2028-12-31
             </h1>
             <p>
-              <a name="quarterpastjanuary"
-                ><a href="#quarterpastjanuary"
-                  >Today is around about quarter past January</a
+              <a name="halfpastnovember"
+                ><a href="#halfpastnovember"
+                  >Today is around about half past November</a
                 ></a
               >
             </p>


### PR DESCRIPTION
- for december, the closest shortcut was in following
  year i.e. january
- changed it to restrict search to same year
- extract `find_closest_shortcut_in_each_year`