### PR TITLE
speedup: use async IO for writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quarterpastmarch"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mike Moran <mike@houseofmoran.com>"]
 edition = "2018"
 
@@ -10,3 +10,4 @@ edition = "2018"
 chrono = "0.4"
 askama = "0.9"
 itertools = "0.8"
+async-std = "1.5"


### PR DESCRIPTION
- convert io parts to async
- speedup: async spawn tasks in `render_pages`
  - for 10 years this takes total runtime from around 15
    seconds to 5 seconds